### PR TITLE
Add `--timeout` option to specify custom timeout when scraping zk servers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,9 @@ services:
 
   # third
   zoo3:
-    image: zookeeper:3.4
+    build:
+      context: zoo-timeout
+    privileged: true  # Needed for iptables drop rule to work in custom entrypoint script
     restart: always
     hostname: zoo3
     ports:
@@ -45,10 +47,10 @@ services:
     image: dabealu/zookeeper-exporter
     ports:
       - 8083:8080
-    command: --zk-host=zoo3
+    command: --zk-host=zoo3 --timeout=5
 
   exp123:
     image: dabealu/zookeeper-exporter
     ports:
       - 8084:8080
-    command: --zk-list="zoo1:2181,zoo2:2181,zoo3:2181"
+    command: --zk-list="zoo1:2181,zoo2:2181,zoo3:2181" --timeout=5

--- a/zoo-timeout/Dockerfile
+++ b/zoo-timeout/Dockerfile
@@ -1,0 +1,11 @@
+FROM zookeeper:3.4
+
+RUN apk add --no-cache iptables
+
+# Add custom entrypoint to set iptables rules and then resume the original entrypoint script
+ADD custom-entrypoint.sh /
+RUN cat /docker-entrypoint.sh >> /custom-entrypoint.sh
+
+# Use custom entrypoint with default command taken from upstream Dockerfile
+ENTRYPOINT ["/custom-entrypoint.sh"]
+CMD ["zkServer.sh", "start-foreground"]

--- a/zoo-timeout/custom-entrypoint.sh
+++ b/zoo-timeout/custom-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Drop traffic to zookeeper
+echo 'about to setup iptables to drop packets on 2181'
+iptables -A INPUT -p tcp --destination-port 2181 -j DROP
+echo 'ip tables rules setup'
+
+# Call the original entrypoint script
+echo 'now calling original entrypoint'
+echo '----'


### PR DESCRIPTION
Make `zoo3` host drop all incoming connections to zookeeper port (tcp/2181) to replicate network timeout events. This means that `exp3` and `exp123` will experience the timeout behaviour descriped in #4.

Fixes: #4