### PR TITLE
try resolve host when got error in connection

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func serveMetrics(location, listen string,  zkOpts *zkOptions) {
 func main() {
 	location := flag.String("location", "/metrics", "metrics location")
 	listen := flag.String("listen", "0.0.0.0:8080", "address to listen on")
-	timeout := flag.Int64("timeout", 120, "timeout for connection to zk servers, in seconds")
+	timeout := flag.Int64("timeout", 30, "timeout for connection to zk servers, in seconds")
 	host := flag.String("zk-host", "127.0.0.1", "zookeeper host")
 	port := flag.String("zk-port", "2181", "zookeeper port")
 	list := flag.String("zk-list", "",

--- a/main.go
+++ b/main.go
@@ -41,10 +41,10 @@ func getMetrics(zkOpts *zkOptions) map[string]string {
 		if err != nil {
 			log.Printf("warning: cannot connect to %s: %v", h.Unresolved, err)
 			metrics[fmt.Sprintf("zk_up{%s}", hostLabel)] = "0"
-			new_tcp, _ := net.ResolveTCPAddr("tcp", h.Unresolved)
-			if new_tcp.IP.String() != h.TCPAddr.IP.String() {
-				log.Printf("INFO: resolve %s to new ip: %s ( old ip was: %s )", h.Unresolved, new_tcp, h.TCPAddr)
-				zkOpts.Hosts[i].TCPAddr = new_tcp
+			newTcp, _ := net.ResolveTCPAddr("tcp", h.Unresolved)
+			if newTcp.IP.String() != h.TCPAddr.IP.String() {
+				log.Printf("INFO: resolve %s to new ip: %s ( old ip was: %s )", h.Unresolved, newTcp, h.TCPAddr)
+				zkOpts.Hosts[i].TCPAddr = newTcp
 			}else{
 				errFatal(err)
 			}


### PR DESCRIPTION
When I tried to use exporter for zookeeper in kubernetes , I faced with problem when pods with zookeeper after restart changed ip address. If exporter does not do new resolve , it stucks in attempt to connection unhealthy zookeeper host. 