### PR TITLE
Fix folder name inside the tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         for OS in linux darwin; do
           echo "building binary for ${OS}"
           GOOS=${OS} GOARCH=amd64 go build -v -o zookeeper-exporter
-          tar -czvf zookeeper-exporter-${{ steps.v.outputs.tag }}-${OS}.tar.gz --transform 's,^,zookeeper-exporter-${{ steps.v.outputs.tag }}-${OS}/,' zookeeper-exporter
+          tar -czvf zookeeper-exporter-${{ steps.v.outputs.tag }}-${OS}.tar.gz --transform "s,^,zookeeper-exporter-${{ steps.v.outputs.tag }}-${OS}/," zookeeper-exporter
         done
         ls -lh
 


### PR DESCRIPTION
When untar the archive of v0.1.5 release, there's a folder named `zookeeper-exporter-v0.1.5-${OS}`, this PR should fix this.