### PR TITLE
change default listen port to 9141

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To build image with different name, pass it to `build.sh` as a first arg.
 ```
 Usage of zookeeper-exporter:
   -listen string
-        address to listen on (default "0.0.0.0:8080")
+        address to listen on (default "0.0.0.0:9141")
   -location string
         metrics location (default "/metrics")
   -timeout int

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 
 func main() {
 	location := flag.String("location", "/metrics", "metrics location")
-	listen := flag.String("listen", "0.0.0.0:8080", "address to listen on")
+	listen := flag.String("listen", "0.0.0.0:9141", "address to listen on")
 	timeout := flag.Int64("timeout", 30, "timeout for connection to zk servers, in seconds")
 	host := flag.String("zk-host", "127.0.0.1", "zookeeper host")
 	port := flag.String("zk-port", "2181", "zookeeper port")


### PR DESCRIPTION
change default listen port to 9141 to align with https://github.com/prometheus/prometheus/wiki/Default-port-allocations