### PR TITLE
replace a dash with an underscore in metric names

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func getMetrics(options *Options) map[string]string {
 			case "": // noop on empty string
 
 			default:
-				metrics[fmt.Sprintf("%s{%s}", kv[0], hostLabel)] = kv[1]
+				metrics[fmt.Sprintf("%s{%s}", strings.ReplaceAll(kv[0], "-", "_"), hostLabel)] = kv[1]
 			}
 		}
 


### PR DESCRIPTION
Prometheus does not allow dashes in metric names.  *https://prometheus.io/docs/practices/naming/*

If you have a namespace in kafka for example kafka-manager the exporter will create metrics name like this:
```
zk_sum_kafka-manager_write_per_namespace
```
This cause that prometheus is not able to read this the output from the exporter. 

In this Pull Request I do simple replace all ```-``` with an ```_```. So that the metric names look like this:
```
zk_sum_kafka_manager_write_per_namespace
```

