### PR TITLE
Replace periods with underscores in metric names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 ### Prometheus zookeeper exporter
+
 Exports `mntr` zookeeper's stats in prometheus format.  
-`zk_followers`, `zk_synced_followers` and `zk_pending_syncs` metrics are available only on cluster leader.  
+`zk_followers`, `zk_synced_followers` and `zk_pending_syncs` metrics are available only on cluster leader.
 
 #### Build
+
 `./build.sh` script builds `dabealu/zookeeper-exporter:latest` docker image.  
-To build image with different name, pass it to `build.sh` as a first arg.  
+To build image with different name, pass it to `build.sh` as a first arg.
 
 #### Usage
+
 **Note:** starting from zookeeper v3.4.10 it's required to have `mntr` command whitelisted (details: [4lw.commands.whitelist](https://zookeeper.apache.org/doc/current/zookeeperAdmin.html)).
 
 **Warning:** flag to specify target zk hosts is changed since `v0.1.10`, see below
+
 ```
 Usage of zookeeper-exporter:
   -listen string
@@ -23,6 +27,7 @@ Usage of zookeeper-exporter:
 ```
 
 An example `docker-compose.yml` can be used for management of clustered zookeeper + exporters:
+
 ```
 # start zk cluster and exporters
 docker-compose up -d
@@ -30,7 +35,7 @@ docker-compose up -d
 # get metrics of first exporter (second and third exporters are on 9142 and 9143 ports)
 curl -s localhost:9141/metrics
 
-# at 8084 port there's exporter which handles multiple zk hosts
+# at 9184 port there's exporter which handles multiple zk hosts
 curl -s localhost:9144/metrics
 
 # shutdown containers
@@ -38,4 +43,5 @@ docker-compose down -v
 ```
 
 #### Dashboard
+
 Example grafana dashboard: https://grafana.com/grafana/dashboards/11442

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     image: dabealu/zookeeper-exporter
     ports:
       - 9141:9141
-    command: --zk-host=zoo1
+    command: --zk-hosts="zoo1:2181"
 
   # second
   zoo2:
@@ -31,7 +31,7 @@ services:
     image: dabealu/zookeeper-exporter
     ports:
       - 9142:9141
-    command: --zk-host=zoo2
+    command: --zk-hosts="zoo2:2181"
 
   # third
   zoo3:
@@ -52,14 +52,14 @@ services:
     image: dabealu/zookeeper-exporter
     ports:
       - 9143:9141
-    command: --zk-host=zoo3 --timeout=5
+    command: --zk-hosts="zoo3:2181" --timeout=5
 
   # multitarget
   exp123:
     image: dabealu/zookeeper-exporter
     ports:
       - 9144:9141
-    command: --zk-list="zoo1:2181,zoo2:2181,zoo3:2181" --timeout=5
+    command: --zk-hosts="zoo1:2181,zoo2:2181,zoo3:2181" --timeout=5
 
   # prometheus server
   prometheus:

--- a/main.go
+++ b/main.go
@@ -49,6 +49,8 @@ const cmdNotExecutedSffx = "is not executed because it is not in the whitelist."
 
 var versionRE = regexp.MustCompile(`^([0-9]+\.[0-9]+\.[0-9]+).*$`)
 
+var metricNameReplacer = strings.NewReplacer("-", "_", ".", "_")
+
 // open tcp connections to zk nodes, send 'mntr' and return result as a map
 func getMetrics(options *Options) map[string]string {
 	metrics := map[string]string{}
@@ -116,7 +118,7 @@ func getMetrics(options *Options) map[string]string {
 			case "": // noop on empty string
 
 			default:
-				metrics[fmt.Sprintf("%s{%s}", strings.ReplaceAll(kv[0], "-", "_"), hostLabel)] = kv[1]
+				metrics[fmt.Sprintf("%s{%s}", metricNameReplacer.Replace(kv[0]), hostLabel)] = kv[1]
 			}
 		}
 


### PR DESCRIPTION
Required due to ZooKeeper sometimes producing metrics with periods e.g. zk_min_autoscaling.json_write_per_namespace

This causes prometheus scrapes to fail with `unsupported character in float`.

![image](https://user-images.githubusercontent.com/5111725/98273793-8effaa80-1f8a-11eb-9e48-3ff436415aea.png)
