### PR TITLE
Giving more feedback when no hosts are provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"os"
 )
 
 func main() {
@@ -21,8 +22,10 @@ func main() {
 	flag.Parse()
 
 	hosts := strings.Split(*zkhosts, ",")
-	if len(hosts) == 0 {
-		log.Fatal("fatal: no target zookeeper hosts specified, exiting")
+	if len(hosts) == 0 || (len(hosts) == 1 && hosts[0] == "") {
+		log.Print("fatal: no target zookeeper hosts specified.")
+		flag.Usage()
+		os.Exit(1)
 	}
 
 	log.Printf("info: zookeeper hosts: %v", hosts)


### PR DESCRIPTION
Running on Ubuntu 20.04, when I ran the exporter as `./main zk-1:2181,zk-2:2181,zk-3:2181` the program would run, but fail to gather data. As someone away from `go` for a few years, it was non-obvious from the error messages that I needed to add a command-line flag.

The particular pathology I experienced was the `host` array was showing `len == 1` with the first value being an empty string.  I added a test for that failure case.

I also split the `log.Fatal` into an explicit `log.Print` and `os.Exit(1)` (requiring the import of `os`), then added in a call to the `flag.Usage()` so someone else who didn't know they needed a flag would be able to see it there.

Thanks for making the exporter available and I hope this PR is a helpful one!