### PR TITLE
Make substitution more reasonable.

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func getMetrics(options *Options) map[string]string {
 			default:
 				var k string
 				if strings.Contains(key, "}") {
-					k = metricNameReplacer.Replace(key)
+					k = metricNameReplacer.Replace(key[0:strings.Index(key, "{")]) + key[strings.Index(key, "{"):]
 					k = strings.Replace(k, "}", ",", 1)
 					k = fmt.Sprintf("%s%s}", k, hostLabel)
 				} else {


### PR DESCRIPTION
We encountered the following case,  Exporter caused confusion in the label format.
 So the replacement should only contain metric name, not label name.


Input: `zk_write_per_namespace{key="solrcloud7",quantile="0.5"}	141.0`
Output: `zk_write_per_namespace{key="solrcloud7"_quantile="0_5",zk_host="localhost:2181"} 141.0`
